### PR TITLE
Метрики Prometheus + Actuator health

### DIFF
--- a/.run/BookingServiceApp(dev).run.xml
+++ b/.run/BookingServiceApp(dev).run.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="BookingServiceApp(dev)" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="ACTIVE_PROFILES" value="dev" />
+    <option name="envFilePaths">
+      <option value="$PROJECT_DIR$/.env" />
+    </option>
+    <module name="booking-service" />
+    <selectedOptions>
+      <option name="environmentVariables" />
+    </selectedOptions>
+    <option name="SPRING_BOOT_MAIN_CLASS" value="ru.masterskaya.BookingServiceApp" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/.run/BookingServiceApp(local).run.xml
+++ b/.run/BookingServiceApp(local).run.xml
@@ -1,0 +1,16 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="BookingServiceApp(local)" type="SpringBootApplicationConfigurationType" factoryName="Spring Boot">
+    <option name="ACTIVE_PROFILES" value="local" />
+    <option name="envFilePaths">
+      <option value="$PROJECT_DIR$/.env" />
+    </option>
+    <module name="booking-service" />
+    <selectedOptions>
+      <option name="environmentVariables" />
+    </selectedOptions>
+    <option name="SPRING_BOOT_MAIN_CLASS" value="ru.masterskaya.BookingServiceApp" />
+    <method v="2">
+      <option name="Make" enabled="true" />
+    </method>
+  </configuration>
+</component>

--- a/README.md
+++ b/README.md
@@ -19,12 +19,12 @@ POSTGRES_PASSWORD=ваш-безопасный-пароль
 KAFKA_CLUSTER_ID=уникальный-id-кластера
 ```
 2. Вариант "Local" (Разработка в IDE/ CLI)
-Используется, когда базы запущены в Docker, а код запускается локально в IDEA
+Используется, когда Postgres, Redis, Kafka, Prometheus UI запущены в Docker, а код запускается локально в IDEA
 
-Шаг 1. Запуск БД, Redis, Kafka
+Шаг 1. Запуск БД, Redis, Kafka, Prometheus UI в Docker:
 
 ```bash
-docker-compose up -d booking-db redis kafka kafka-init-topics
+docker-compose up -d booking-db redis kafka kafka-init-topics prometheus
 ```
 
 Шаг 2. Запуск сервиса 
@@ -69,8 +69,13 @@ docker compose logs -f
 # Логи конкретного сервиса
 docker compose logs -f booking-service
 ```
+6. После запуска приложения сервисы будут доступны по следующим URL:
+- Booking Service: http://localhost:8080
+- Prometheus UI: http://localhost:9090
+- Health Check: http://localhost:8080/actuator/health
+- Metrics: http://localhost:8080/actuator/prometheus
 
-6. Для остановки приложения используйте команду:
+7. Для остановки приложения используйте команду:
 
 ```bash
 docker-compose down

--- a/booking-service/pom.xml
+++ b/booking-service/pom.xml
@@ -35,6 +35,11 @@
         </dependency>
 
         <dependency>
+            <groupId>io.micrometer</groupId>
+            <artifactId>micrometer-registry-prometheus</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-flyway</artifactId>
         </dependency>
@@ -64,6 +69,11 @@
         <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-redis</artifactId>
         </dependency>
     </dependencies>
 

--- a/booking-service/src/main/resources/application.yaml
+++ b/booking-service/src/main/resources/application.yaml
@@ -24,7 +24,22 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,info
+        include: health,info,prometheus,metrics
   endpoint:
     health:
       show-details: always
+      show-components: always
+      probes:
+        enabled: true
+      group:
+        readiness:
+          include: db,redis,readinessState
+  health:
+    db:
+      enabled: true
+    redis:
+      enabled: true
+  prometheus:
+    metrics:
+      export:
+        enabled: true

--- a/config/prometheus.yml
+++ b/config/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 15s
+
+scrape_configs:
+  - job_name: 'booking-service'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      - targets: ['host.docker.internal:8080']

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -91,6 +91,19 @@ services:
       timeout: 10s
       retries: 10
 
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./config/prometheus.yml:/etc/prometheus/prometheus.yml
+    healthcheck:
+      test: [ "CMD", "wget", "--spider", "--quiet", "http://localhost:9090/-/ready" ]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+
 volumes:
   booking-db-data:
   kafka_data:


### PR DESCRIPTION
- Подключить Actuator (health, info)
- Экспорт Prometheus-метрик (/actuator/prometheus)
- Проверки готовности зависимостей (DB/Redis)
- Метрики и health доступны в локальном профиле
- README содержит URL и способ проверки